### PR TITLE
Add support for --disable-default-exception-handler on cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,13 @@ inital ``MINOR`` releases such as ``18.0`` or ``19.2``.
 
 .. snip
 
+Unreleased
+~~~~~~~~~~
+- Add support for ``--disable-default-exception-handler`` option when
+  starting a worker to disable RQ's default exception handler.
+
+  **Requires rq 1.0 or higher.**
+
 18.3 (2018-12-20)
 ~~~~~~~~~~~~~~~~~
 

--- a/src/flask_rq2/cli.py
+++ b/src/flask_rq2/cli.py
@@ -131,11 +131,13 @@ def info(rq, ctx, path, interval, raw, only_queues, only_workers, by_queue,
 @click.option('--pid',
               help='Write the process ID number to a file at '
                    'the specified path')
+@click.option('--disable-default-exception-handler', '-d', is_flag=True,
+              help='Disable RQ\'s default exception handler')
 @click.argument('queues', nargs=-1)
 @rq_command()
 def worker(rq, ctx, burst, logging_level, name, path, results_ttl,
            worker_ttl, verbose, quiet, sentry_dsn, exception_handler, pid,
-           queues):
+           disable_default_exception_handler, queues):
     "Starts an RQ worker."
     ctx.invoke(
         rq_cli.worker,
@@ -151,6 +153,7 @@ def worker(rq, ctx, burst, logging_level, name, path, results_ttl,
         exception_handler=exception_handler or rq._exception_handlers,
         pid=pid,
         queues=queues or rq.queues,
+        disable_default_exception_handler=disable_default_exception_handler,
         **shared_options(rq)
     )
 


### PR DESCRIPTION
Just forward this new option on Flask-RQ2 cli, [available since RQ 1.0](https://github.com/rq/rq/blob/v1.0/rq/cli/cli.py#L190)