### PR TITLE
Add on_success and on_failure callback kwargs

### DIFF
--- a/src/flask_rq2/app.py
+++ b/src/flask_rq2/app.py
@@ -224,7 +224,8 @@ class RQ(object):
         return callback
 
     def job(self, func_or_queue=None, timeout=None, result_ttl=None, ttl=None,
-            depends_on=None, at_front=None, meta=None, description=None):
+            depends_on=None, at_front=None, meta=None, description=None,
+            on_success=None, on_failure=None):
         """
         Decorator to mark functions for queuing via RQ, e.g.::
 
@@ -274,6 +275,14 @@ class RQ(object):
         :param description: Description of the job.
         :type description: str
 
+        :param on_success: Callback when job success.
+        :type on_success: Callable
+
+        :param on_failure: Callback when job fails.
+        :type on_failure: Callable
+
+
+
         """
         if callable(func_or_queue):
             func = func_or_queue
@@ -295,6 +304,8 @@ class RQ(object):
                 at_front=at_front,
                 meta=meta,
                 description=description,
+                on_success=on_success,
+                on_failure=on_failure,
             )
             wrapped.helper = helper
             for function in helper.functions:

--- a/src/flask_rq2/functions.py
+++ b/src/flask_rq2/functions.py
@@ -15,7 +15,7 @@ class JobFunctions(object):
     functions = ['queue', 'schedule', 'cron']
 
     def __init__(self, rq, wrapped, queue_name, timeout, result_ttl, ttl,
-                 depends_on, at_front, meta, description):
+                 depends_on, at_front, meta, description, on_success, on_failure):
         self.rq = rq
         self.wrapped = wrapped
         self._queue_name = queue_name
@@ -28,6 +28,8 @@ class JobFunctions(object):
         self._at_front = at_front
         self._meta = meta
         self._description = description
+        self._on_success = on_success
+        self._on_failure = on_failure
 
     def __repr__(self):
         full_name = '.'.join([self.wrapped.__module__, self.wrapped.__name__])
@@ -104,6 +106,14 @@ class JobFunctions(object):
                        :mod:`UUID <uuid>`.
         :type job_id: str
 
+        :param on_success: A callback when the job suceeds. Defaults
+                           to None
+        :type job_id: Callable
+
+        :param on_failure: A callback when the job fails. Defaults
+                           to None
+        :type job_id: Callable
+
         :param at_front: Whether or not the job is queued in front of all other
                          enqueued jobs.
         :type at_front: bool
@@ -124,6 +134,8 @@ class JobFunctions(object):
         at_front = kwargs.pop('at_front', self._at_front)
         meta = kwargs.pop('meta', self._meta)
         description = kwargs.pop('description', self._description)
+        on_success = kwargs.pop('on_success', self._on_success)
+        on_failure = kwargs.pop('on_failure', self._on_failure)
         return self.rq.get_queue(queue_name).enqueue_call(
             self.wrapped,
             args=args,
@@ -136,6 +148,8 @@ class JobFunctions(object):
             at_front=at_front,
             meta=meta,
             description=description,
+            on_success=on_success,
+            on_failure=on_failure,
         )
 
     def schedule(self, time_or_delta, *args, **kwargs):


### PR DESCRIPTION
As noted in #116 there is no support for `on_success` or `on_failure` callbacks. This adds them

I'm using this in my application and it seems to work fine. If someone else would like to test, it can be installed with the following:

## Pip

```
$ pip install 'git+https://github.com/mzpqnxow/Flask-RQ2@failure-success-callbacks#egg=Flask-RQ2'  # If your ~/.gitconfig requires HTTPS
$ pip install 'git+ssh://github.com/mzpqnxow/Flask-RQ2@failure-success-callbacks#egg=Flask-RQ2'  # If your ~/.gitconfig requires SSH
```

## Manual / from the filesystem using pip or setuptools

```
$ git clone https://github.com/mzpqnxow/Flask-RQ2 --branch failure-success-callbacks && cd Flask-RQ2
$ pip install .
```

or ...

```
$ python setup.py install
```

## As a dependency in setuptools

In `setup.cfg`, use:

```
[options]
...
install_requires =
    ...
    Flask-RQ2 @ git+https://github.com/mzpqnxow/Flask-RQ2@failure-success-callbacks#egg=Flask-RQ2
    ...
```

## As a dependency in `requirements.txt` only

If using `requirements.txt` only:

```
...
git+https://github.com/mzpqnxow/Flask-RQ2@failure-success-callbacks#egg=Flask-RQ2
...
```

## As a dependency in `requirements.txt` and `constraints.txt` (the "proper" way to do this)

`requirements.txt`:
```
...
Flask-RQ2
...
```

`constraints.txt`:
```
Flask-RQ2 @ git+https://github.com/mzpqnxow/Flask-RQ2@failure-success-callbacks#egg=Flask-RQ2
```


## Caveats

I don't make exhaustive use of all of the features of Flask-RQ2 so it's quite possible I made a mistake. Anyone who may want to test/review is appreciated. This has *NOT* been reviewed by the Flask-RQ2 devs


## Usage

The use is as one would expect, it just adds two kwargs to the `queue()` function. The usage is as described in #116 , duplicated here:

```python
from flask_rq2 import RQ
from flask import Flask

app = Flask(__name__)
rq = RQ()

rq.init_app(app)

@rq.job()
def do_something():
    return "OK"

def report_success(*args, **kargs):
    print("success")

def report_failure(*args, **kargs):
    print("fail")

def try_to_queue():
    do_something.queue(queue="default", on_success = report_success, on_failure = report_failure)

try_to_queue()
```

Alternately, you can use the following style, opting to specify the callbacks when defining the function- same as with any other kwargs:

```python

...

@rq.job(on_success = report_success, on_failure = report_failure)
def do_something():
    return "OK"

...

def try_to_queue():
    do_something.queue(queue="default")

...

```
